### PR TITLE
Updated chrome.app.getDetails() to use chrome.runtime.getManifest()

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -37,7 +37,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
 });
 
 function getVersion(){
-    var extension_version = chrome.app.getDetails();
+    var extension_version = chrome.runtime.getManifest();
     return extension_version.version;
 }
 


### PR DESCRIPTION
Fixing Issue [Issue 62](https://github.com/inuyasha82/chrome_parameters/issues/62)

Replaced `chrome.app.getDetails();` with `chrome.runtime.getManifest();`

Tested in chrome and the version still shows - unsure how else to test it!